### PR TITLE
修改member_profile、member_auth外鍵設定

### DIFF
--- a/DATA/all.sql
+++ b/DATA/all.sql
@@ -299,7 +299,22 @@ select * from member_auth;
 select * from member_profile;
 select * from member_basic;
 
+ALTER TABLE member_profile
+DROP FOREIGN KEY member_profile_ibfk_1;
 
+ALTER TABLE member_auth
+DROP FOREIGN KEY member_auth_ibfk_1;
+
+ALTER TABLE member_profile
+ADD CONSTRAINT member_profile_ibfk_1
+FOREIGN KEY (member_id) REFERENCES member_basic(member_id) ON DELETE CASCADE;
+
+ALTER TABLE member_auth
+ADD CONSTRAINT member_auth_ibfk_1
+FOREIGN KEY (member_id) REFERENCES member_basic(member_id) ON DELETE CASCADE;
+
+SHOW CREATE TABLE member_profile;
+SHOW CREATE TABLE member_auth;
 
 CREATE TABLE Products (
     id INT AUTO_INCREMENT PRIMARY KEY,           -- 主鍵


### PR DESCRIPTION
刪掉外鍵關聯 
重新設定外鍵關聯 並添加設定使刪除 memberBasic 某筆資料時 會同時刪除其他關聯表的那筆資料
最後兩條檢查 最後面會有FOREIGN KEY (member_id) REFERENCES member_basic (member_id) ON DELETE CASCADE